### PR TITLE
README.md: Fix incorrect case of module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ exports.module = function(factory){
 In your test files require AutoFixture then pass the AutoFixture variable to the fixtures class
 ```js
 //tests.js
-var factory = require('AutoFixture')
+var factory = require('autofixture')
 require('./fixtures')(factory)
 ```
 Now you can use the factory to access your defined fixtures.


### PR DESCRIPTION
When installed via NPM, the module is installed to `node_modules/autofixture` (as per the `name` field in `package.json`). This causes a case sensitivity issue on OS' that are case sensitive (Unix / OSX when created with a case-sensitive partition) as it's looking for a `package.json` in `node_modules/AutoFixture`, which of course doesn't actually exist.

I've updated the read me to reflect this. An alternative would be to rename the package, but this seems like the simplest solution.
