### PR TITLE
Use example.com for fixture email

### DIFF
--- a/src/builder-functions.js
+++ b/src/builder-functions.js
@@ -36,7 +36,7 @@ String.prototype.asEmail = function(){
   return function(incrementer){
     return{
       name:fieldName,
-      value: "email"+incrementer+"@email.com"
+      value: "email"+incrementer+"@example.com"
     };
   };
 };

--- a/test/autofixture_specs.js
+++ b/test/autofixture_specs.js
@@ -180,8 +180,8 @@ describe("Creating Single Fixture",function(){
     		'email'.asEmail()
     	]);
 
-    	Factory.create('Email').email.should.equal('email1@email.com');
-    	Factory.create('Email').email.should.equal('email2@email.com');
+    	Factory.create('Email').email.should.equal('email1@example.com');
+    	Factory.create('Email').email.should.equal('email2@example.com');
     });
 
     it('should be able to pick a random item from a provided array', function(){


### PR DESCRIPTION
- Now Register.com has `email.com`. If someone own the domain, they can get the mail from generated address.
- IANA provides `example.com` for documentation purpose. But sometimes we can use it for testing purpose. https://en.wikipedia.org/wiki/Example.com